### PR TITLE
Last upgrade for django version to 5.2!

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "bibtexparser>=1.4.3",
     "certifi>=2025.1.31",
     "crispy-bootstrap4>=2024.10",
-    "django>=5.1.7",
+    "django==5.2",
     "django-crispy-forms>=2.3",
     "django-environ>=0.12.0",
     "django-model-utils>=5.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -117,7 +117,7 @@ requires-dist = [
     { name = "bibtexparser", specifier = ">=1.4.3" },
     { name = "certifi", specifier = ">=2025.1.31" },
     { name = "crispy-bootstrap4", specifier = ">=2024.10" },
-    { name = "django", specifier = ">=5.1.7" },
+    { name = "django", specifier = "==5.2" },
     { name = "django-auth-ldap", marker = "extra == 'auth'", specifier = "==5.1.0" },
     { name = "django-crispy-forms", specifier = ">=2.3" },
     { name = "django-environ", specifier = ">=0.12.0" },
@@ -166,16 +166,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.1.7"
+version = "5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/57/11186e493ddc5a5e92cc7924a6363f7d4c2b645f7d7cb04a26a63f9bfb8b/Django-5.1.7.tar.gz", hash = "sha256:30de4ee43a98e5d3da36a9002f287ff400b43ca51791920bfb35f6917bfe041c", size = 10716510 }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/1b/c6da718c65228eb3a7ff7ba6a32d8e80fa840ca9057490504e099e4dd1ef/Django-5.2.tar.gz", hash = "sha256:1a47f7a7a3d43ce64570d350e008d2949abe8c7e21737b351b6a1611277c6d89", size = 10824891 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/0f/7e042df3d462d39ae01b27a09ee76653692442bc3701fbfa6cb38e12889d/Django-5.1.7-py3-none-any.whl", hash = "sha256:1323617cb624add820cb9611cdcc788312d250824f92ca6048fda8625514af2b", size = 8276912 },
+    { url = "https://files.pythonhosted.org/packages/63/e0/6a5b5ea350c5bd63fe94b05e4c146c18facb51229d9dee42aa39f9fc2214/Django-5.2-py3-none-any.whl", hash = "sha256:91ceed4e3a6db5aedced65e3c8f963118ea9ba753fc620831c77074e620e7d83", size = 8301361 },
 ]
 
 [[package]]


### PR DESCRIPTION
Supported until Q2 2028: https://www.djangoproject.com/download/#supported-versions