### PR TITLE
Add user search plugin

### DIFF
--- a/coldfront/config/plugins/keycloak_user_search.py
+++ b/coldfront/config/plugins/keycloak_user_search.py
@@ -1,0 +1,18 @@
+from coldfront.config.env import ENV
+
+# ----------------------------------------------------------------------------
+#  This enables searching for users via Keycloak
+# ----------------------------------------------------------------------------
+
+KEYCLOAK_BASE_URL = ENV.str(
+    "KEYCLOAK_BASE_URL", default="https://sso-test.hpc.nyu.edu/"
+)
+
+KEYCLOAK_USERNAME = ENV.str("KEYCLOAK_USERNAME")
+KEYCLOAK_PASSWORD = ENV.str("KEYCLOAK_PASSWORD")
+KEYCLOAK_CLIENT_ID = ENV.str("KEYCLOAK_CLIENT_ID")
+KEYCLOAK_CLIENT_SECRET = ENV.str("KEYCLOAK_CLIENT_SECRET")
+
+ADDITIONAL_USER_SEARCH_CLASSES = [
+    "coldfront.plugins.keycloak_user_search.search.KeycloakUserSearch"
+]

--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -22,6 +22,7 @@ plugin_configs = {
     'PLUGIN_AUTH_OIDC': 'plugins/openid.py',
     'PLUGIN_AUTH_LDAP': 'plugins/ldap.py',
     'PLUGIN_LDAP_USER_SEARCH': 'plugins/ldap_user_search.py',
+    'PLUGIN_KEYCLOAK_USER_SEARCH': 'plugins/keycloak_user_search.py',
 }
 
 # This allows plugins to be enabled via environment variables. Can alternatively

--- a/coldfront/plugins/keycloak_user_search/apps.py
+++ b/coldfront/plugins/keycloak_user_search/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class KeycloakUserSearchConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "keycloak_user_search"

--- a/coldfront/plugins/keycloak_user_search/keycloak_config.py
+++ b/coldfront/plugins/keycloak_user_search/keycloak_config.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from coldfront.core.utils.common import import_from_settings
+from httpx import URL
+
+
+@dataclass
+class KeycloakClientConfig:
+    base_url: URL = URL(import_from_settings("KEYCLOAK_BASE_URL"))
+    username: str = import_from_settings("KEYCLOAK_USERNAME")
+    password: str = import_from_settings("KEYCLOAK_PASSWORD")
+    client_id: str = import_from_settings("KEYCLOAK_CLIENT_ID")
+    client_secret: str = import_from_settings("KEYCLOAK_CLIENT_SECRET")
+    token_path: str = "realms/hpc/protocol/openid-connect/token"
+    search_path: str = "admin/realms/hpc/users?search="
+    search_username_path: str = "admin/realms/hpc/users?username="

--- a/coldfront/plugins/keycloak_user_search/search.py
+++ b/coldfront/plugins/keycloak_user_search/search.py
@@ -1,0 +1,84 @@
+from coldfront.core.user.utils import UserSearch
+from coldfront.plugins.keycloak_user_search.keycloak_config import KeycloakClientConfig
+import logging
+from httpx import Client, URL, Headers
+
+logger = logging.getLogger(__name__)
+
+
+class KeycloakClient:
+    def __init__(self):
+        self.config: KeycloakClientConfig = KeycloakClientConfig()
+        self.token: str = str()
+        self.client: Client = Client()
+
+    def get_access_token(self) -> None:
+        token_url: URL = self.config.base_url.join(self.config.token_path)
+        data = {
+            "username": self.config.username,
+            "password": self.config.password,
+            "client_id": self.config.client_id,
+            "client_secret": self.config.client_secret,
+            "grant_type": "password",
+        }
+        logger.info(f"base_url is: {self.config.base_url}")
+        logger.info(f"token_url is : {token_url}")
+        resp = self.client.post(token_url, data=data).raise_for_status()
+        self.token = resp.json()["access_token"]
+        return
+
+    def get_all_fields_matches(self, input_str: str) -> list[dict]:
+        headers = Headers(
+            {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.token}",
+            }
+        )
+        search_url = self.config.base_url.join(self.config.search_path + input_str)
+        result = self.client.get(search_url, headers=headers).raise_for_status().json()
+        return result
+
+    def get_username_matches(self, input_str: str) -> list[dict]:
+        headers = Headers(
+            {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.token}",
+            }
+        )
+        search_url = self.config.base_url.join(
+            self.config.search_username_path + input_str
+        )
+        result = self.client.get(search_url, headers=headers).raise_for_status().json()
+        return result
+
+
+class KeycloakUserSearch(UserSearch):
+    search_source = "Keycloak"
+
+    def __init__(self, *args, **kwargs):
+        self.keycloak_client = KeycloakClient()
+        super().__init__(*args, **kwargs)
+
+    def search_a_user(self, user_search_string=None, search_by="all_fields"):
+        self.keycloak_client.get_access_token()
+        matches: list[dict] = []
+        if search_by == "all_fields":
+            matches = self.keycloak_client.get_all_fields_matches(user_search_string)
+        elif search_by == "username_only":
+            matches = self.keycloak_client.get_username_matches(user_search_string)
+        else:
+            raise ValueError("search_by must be one of all_fields, username_only")
+
+        if matches == []:
+            logger.info("Keycloak-user-search: No matchig users found!")
+
+        return [
+            {
+                "username": match["username"],
+                "last_name": match.get("lastName", ""),
+                "first_name": match.get("firstName", ""),
+                "email": match.get("email", ""),
+                "source": self.search_source,
+            }
+            for match in matches
+        ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ dependencies = [
     "redis>=5.2.1",
     "requests>=2.32.3",
     "wheel>=0.45.1",
-    "python-dateutil>=2.9.0"
+    "python-dateutil>=2.9.0",
+    "httpx>=0.28.1",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,20 @@ revision = 1
 requires-python = ">=3.12"
 
 [[package]]
+name = "anyio"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916 },
+]
+
+[[package]]
 name = "asgiref"
 version = "3.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -86,6 +100,7 @@ dependencies = [
     { name = "faker" },
     { name = "fontawesome-free" },
     { name = "formencode" },
+    { name = "httpx" },
     { name = "humanize" },
     { name = "python-dateutil" },
     { name = "redis" },
@@ -134,6 +149,7 @@ requires-dist = [
     { name = "fontawesome-free", specifier = ">=5.15.4" },
     { name = "formencode", specifier = ">=2.1.1" },
     { name = "gunicorn", marker = "extra == 'prod'", specifier = "==23.0.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "humanize", specifier = ">=4.11.0" },
     { name = "ldap3", marker = "extra == 'auth'", specifier = "==2.9.1" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
@@ -387,6 +403,43 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259 },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551 },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
 name = "humanize"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -536,6 +589,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
 name = "sqlparse"
 version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -560,6 +622,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/60/47d92293d9bc521cd2301e423a358abfac0ad409b3a1606d8fbae1321961/types_python_dateutil-2.9.0.20241206.tar.gz", hash = "sha256:18f493414c26ffba692a72369fea7a154c502646301ebfe3d56a04b3767284cb", size = 13802 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/b3/ca41df24db5eb99b00d97f89d7674a90cb6b3134c52fb8121b6d8d30f15c/types_python_dateutil-2.9.0.20241206-py3-none-any.whl", hash = "sha256:e248a4bc70a486d3e3ec84d0dc30eec3a5f979d6e7ee4123ae043eedbb987f53", size = 14384 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/3e/b00a62db91a83fff600de219b6ea9908e6918664899a2d85db222f4fbf19/typing_extensions-4.13.0.tar.gz", hash = "sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b", size = 106520 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/86/39b65d676ec5732de17b7e3c476e45bb80ec64eb50737a8dce1a4178aba1/typing_extensions-4.13.0-py3-none-any.whl", hash = "sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5", size = 45683 },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes https://github.com/NYU-RTS/rts-coldfront/issues/27

Easier to add it in-tree to prevent circular dependency/import issues. 

Search for users in Keycloak, even if they are not present in the Coldfront database! Reference implementation:https://github.com/nerc-project/coldfront-plugin-keycloak.git