### PR TITLE
debugpy: use cli instead of api

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -5,15 +5,6 @@ import sys
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "coldfront.config.settings")
 
-    from django.conf import settings
-
-    if settings.DEBUG:
-        if os.environ.get("RUN_MAIN"):
-            import debugpy
-
-            debugpy.listen(("0.0.0.0", 5678))
-            print("Attached!")
-
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
- enable debugpy in debug mode, minor reorg of dependencies
- don't use debugpy API, launch gunicorn under debugpy via the CLI instead
