### PR TITLE
install slurm plugin separately in all Containerfiles to avoid circular dep

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -47,6 +47,11 @@ ENV UV_CACHE_DIR=/app/.cache/uv
 
 RUN uv sync --locked --extra prod
 
+# Installed separately (not in pyproject.toml) because the plugin depends on coldfront,
+# creating a circular dependency if listed there. Django discovers its management commands
+# via INSTALLED_APPS at runtime, so a separate install is sufficient.
+RUN uv pip install "git+https://github.com/NYU-RTS/rts-coldfront-slurm-plugin@use-newer-client"
+
 RUN chgrp -R 0 /app/.cache && \
     chmod -R g=u /app/.cache
 

--- a/Containerfile.debug
+++ b/Containerfile.debug
@@ -47,6 +47,11 @@ ENV UV_CACHE_DIR=/app/.cache/uv
 
 RUN uv sync --locked --extra prod
 
+# Installed separately (not in pyproject.toml) because the plugin depends on coldfront,
+# creating a circular dependency if listed there. Django discovers its management commands
+# via INSTALLED_APPS at runtime, so a separate install is sufficient.
+RUN uv pip install "git+https://github.com/NYU-RTS/rts-coldfront-slurm-plugin@use-newer-client"
+
 RUN chgrp -R 0 /app/.cache && \
     chmod -R g=u /app/.cache
 

--- a/Containerfile.debugpy
+++ b/Containerfile.debugpy
@@ -37,6 +37,10 @@ COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --extra prod --dev
 
+# Installed separately (not in pyproject.toml) because the plugin depends on coldfront,
+# creating a circular dependency if listed there. Django discovers its management commands
+# via INSTALLED_APPS at runtime, so a separate install is sufficient.
+RUN uv pip install "git+https://github.com/NYU-RTS/rts-coldfront-slurm-plugin@use-newer-client"
 
 # Copy built bundles/manifest from frontend stage into the backend image
 COPY --from=frontend /app/coldfront/static/bundles /app/coldfront/static/bundles


### PR DESCRIPTION
Without this, we run into mismatched circular dependency issues!

Best to move the slurm rest plugin in-tree in the future after it matures
