### PR TITLE
fix: n+1 for REST API projects

### DIFF
--- a/coldfront/plugins/api/views.py
+++ b/coldfront/plugins/api/views.py
@@ -11,7 +11,6 @@ from django.db.models.functions import Cast
 from django_filters import rest_framework as filters
 from rest_framework import viewsets
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
-
 from simple_history.utils import get_history_model_for_model
 
 from coldfront.core.allocation.models import Allocation, AllocationChangeRequest

--- a/coldfront/plugins/api/views.py
+++ b/coldfront/plugins/api/views.py
@@ -281,7 +281,7 @@ class ProjectViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.ProjectSerializer
 
     def get_queryset(self):
-        projects = Project.objects.prefetch_related("status")
+        projects = Project.objects.select_related("status", "pi", "school")
 
         if not (
             self.request.user.is_superuser
@@ -297,6 +297,7 @@ class ProjectViewSet(viewsets.ReadOnlyModelViewSet):
                     )
                 )
                 .distinct()
+                .select_related("pi", "school", "status")
                 .order_by("pi")
             )
 

--- a/coldfront/plugins/api/views.py
+++ b/coldfront/plugins/api/views.py
@@ -6,7 +6,7 @@ import logging
 from datetime import timedelta
 
 from django.contrib.auth import get_user_model
-from django.db.models import ExpressionWrapper, F, OuterRef, Q, Subquery, fields
+from django.db.models import ExpressionWrapper, F, OuterRef, Q, Subquery, fields, Prefetch
 from django.db.models.functions import Cast
 from django_filters import rest_framework as filters
 from rest_framework import viewsets
@@ -14,7 +14,7 @@ from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from simple_history.utils import get_history_model_for_model
 
 from coldfront.core.allocation.models import Allocation, AllocationChangeRequest
-from coldfront.core.project.models import Project
+from coldfront.core.project.models import Project, ProjectUser
 from coldfront.core.resource.models import Resource
 from coldfront.plugins.api import serializers
 
@@ -301,10 +301,16 @@ class ProjectViewSet(viewsets.ReadOnlyModelViewSet):
             )
 
         if self.request.query_params.get("project_users") in ["True", "true"]:
-            projects = projects.prefetch_related("projectuser_set")
+            projects = projects.prefetch_related(
+                Prefetch("projectuser_set", queryset=ProjectUser.objects.select_related("user", "status", "role"))
+            )
 
         if self.request.query_params.get("allocations") in ["True", "true"]:
-            projects = projects.prefetch_related("allocation_set")
+            projects = projects.prefetch_related(
+                Prefetch(
+                    "allocation_set", queryset=Allocation.objects.select_related("status").prefetch_related("resources")
+                )
+            )
 
         if self.request.query_params.get("project_attributes") in ["True", "true"]:
             projects = projects.prefetch_related("projectattribute_set")


### PR DESCRIPTION
Still leaves out an N+1 for Resource per Allocation for now as that is caused by Allocation.get_resources_as_string

this brings total query walltime down from 39s to 6s with the current state of the projects portal.